### PR TITLE
Add check for no grok patterns case

### DIFF
--- a/lib/fluent/plugin/grok.rb
+++ b/lib/fluent/plugin/grok.rb
@@ -51,7 +51,7 @@ module Fluent
           @parsers << expand_pattern_expression(grok_conf["pattern"], grok_conf)
         end
       end
-      if @parsers.size.zero?
+      if @parsers.empty?
         raise Fluent::ConfigError, 'no grok patterns. Check configuration, e.g. typo, configuration syntax, etc'
       end
     end

--- a/lib/fluent/plugin/grok.rb
+++ b/lib/fluent/plugin/grok.rb
@@ -51,6 +51,9 @@ module Fluent
           @parsers << expand_pattern_expression(grok_conf["pattern"], grok_conf)
         end
       end
+      if @parsers.size.zero?
+        raise Fluent::ConfigError, 'no grok patterns. Check configuration, e.g. typo, configuration syntax, etc'
+      end
     end
 
     private

--- a/test/test_grok_parser.rb
+++ b/test/test_grok_parser.rb
@@ -157,6 +157,12 @@ class GrokParserTest < ::Test::Unit::TestCase
     end
   end
 
+  def test_no_grok_patterns
+    assert_raise Fluent::ConfigError do
+      create_driver('')
+    end
+  end
+
   private
 
   def create_driver(conf)

--- a/test/test_grok_parser_in_tcp.rb
+++ b/test/test_grok_parser_in_tcp.rb
@@ -29,12 +29,18 @@ class TcpInputWithGrokTest < Test::Unit::TestCase
     bind 127.0.0.1
     <parse>
       @type grok
+      <grok>
+        pattern %{GREEDYDATA:message}
+      </grok>
     </parse>
   ]
   IPv6_CONFIG = BASE_CONFIG + %[
     bind ::1
     <parse>
       @type grok
+      <grok>
+        pattern %{GREEDYDATA:message}
+      </grok>
     </parse>
   ]
 

--- a/test/test_multiline_grok_parser.rb
+++ b/test/test_multiline_grok_parser.rb
@@ -95,6 +95,12 @@ TEXT
     end
   end
 
+  def test_no_grok_patterns
+    assert_raise Fluent::ConfigError do
+      create_driver('')
+    end
+  end
+
   private
 
   def create_driver(conf)


### PR DESCRIPTION
This avoids the troubles that users write wrong configuration, e.g. typo, version mismatch, etc.