### PR TITLE
Use String#sub instead of String#sub!

### DIFF
--- a/lib/fluent/plugin/grok.rb
+++ b/lib/fluent/plugin/grok.rb
@@ -131,7 +131,7 @@ module Fluent
         else
           replacement_pattern = "(?:#{curr_pattern})"
         end
-        pattern.sub!(m[0]) do |s|
+        pattern = pattern.sub(m[0]) do |s|
           replacement_pattern
         end
       end

--- a/test/test_grok_parser.rb
+++ b/test/test_grok_parser.rb
@@ -158,37 +158,39 @@ class GrokParserTest < ::Test::Unit::TestCase
     end
   end
 
-  test "no grok patterns" do
-    assert_raise Fluent::ConfigError do
-      create_driver('')
+  sub_test_case "configure" do
+    test "no grok patterns" do
+      assert_raise Fluent::ConfigError do
+        create_driver('')
+      end
     end
-  end
 
-  test "invalid config value type" do
-    assert_raise Fluent::ConfigError do
-      create_driver(%[
+    test "invalid config value type" do
+      assert_raise Fluent::ConfigError do
+        create_driver(%[
+          <grok>
+            pattern %{PATH:path:foo}
+          </grok>
+        ])
+      end
+    end
+
+    test "invalid config value type and normal grok pattern" do
+      d = create_driver(%[
         <grok>
           pattern %{PATH:path:foo}
         </grok>
+        <grok>
+          pattern %{IP:ip_address}
+        </grok>
       ])
+      assert_equal(1, d.instance.instance_variable_get(:@grok).parsers.size)
+      logs = $log.instance_variable_get(:@logger).instance_variable_get(:@logdev).logs
+      error_logs = logs.grep(/error_class/)
+      assert_equal(1, error_logs.size)
+      error_message = error_logs.first[/error="(.+)"/, 1]
+      assert_equal("unknown value conversion for key:'path', type:'foo'", error_message)
     end
-  end
-
-  test "invalid config value type and normal grok pattern" do
-    d = create_driver(%[
-      <grok>
-        pattern %{PATH:path:foo}
-      </grok>
-      <grok>
-        pattern %{IP:ip_address}
-      </grok>
-    ])
-    assert_equal(1, d.instance.instance_variable_get(:@grok).parsers.size)
-    logs = $log.instance_variable_get(:@logger).instance_variable_get(:@logdev).logs
-    error_logs = logs.grep(/error_class/)
-    assert_equal(1, error_logs.size)
-    error_message = error_logs.first[/error="(.+)"/, 1]
-    assert_equal("unknown value conversion for key:'path', type:'foo'", error_message)
   end
 
   sub_test_case "grok_name_key" do

--- a/test/test_grok_parser.rb
+++ b/test/test_grok_parser.rb
@@ -191,6 +191,16 @@ class GrokParserTest < ::Test::Unit::TestCase
       error_message = error_logs.first[/error="(.+)"/, 1]
       assert_equal("unknown value conversion for key:'path', type:'foo'", error_message)
     end
+
+    test "keep original configuration" do
+      config = %[
+        <grok>
+          pattern %{INT:user_id:integer} paid %{NUMBER:paid_amount:float}
+        </grok>
+      ]
+      d = create_driver(config)
+      assert_equal("%{INT:user_id:integer} paid %{NUMBER:paid_amount:float}", d.instance.config.elements("grok").first["pattern"])
+    end
   end
 
   sub_test_case "grok_name_key" do


### PR DESCRIPTION
Because String#sub! is a destructive method.
Built-in in_tail plugin will configure the parse section twice.
The in_tail plugin will use raw parse section at the 1st time and it
will use parse section with expanded grok pattern without types.

We can avoid this behavior when we stop using a destructive method to
expand grok patterns.

Fix #63